### PR TITLE
Stable history using reversely-ordered CUSUM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ The bfast package has been tested under Python 3.*. The required Python dependen
 - pyopencl==2018.2.5
 - scikit-learn==0.20.3
 - scipy==1.2.1
+- statsmodels==0.11.1
 - matplotlib==2.2.2
 - wget==3.2
 - Sphinx==2.2.0

--- a/bfast/base.py
+++ b/bfast/base.py
@@ -14,6 +14,7 @@ class BFASTMonitorBase(ABC):
             start_monitor,
             freq=365,
             k=3,
+            history=None,
             hfrac=0.25,
             trend=True,
             level=0.05,
@@ -24,6 +25,7 @@ class BFASTMonitorBase(ABC):
         self.start_monitor = start_monitor
         self.freq = freq
         self.k = k
+        self.history = history
         self.hfrac = hfrac
         self.trend = trend
         self.level = level

--- a/bfast/models.py
+++ b/bfast/models.py
@@ -40,7 +40,7 @@ class BFASTMonitor(object):
     verbose : int, optional (default=0)
         The verbosity level (0=no output, 1=output).
 
-    backend : str, default 'opencl"
+    backend : str, default 'opencl'
         Specifies the implementation that shall be used:
         backend='python' resorts to the non-optimized Python
         version; backend='opencl' resorts to the optimized

--- a/bfast/models.py
+++ b/bfast/models.py
@@ -24,6 +24,13 @@ class BFASTMonitor(object):
     k : int, default 3
         The number of harmonic terms.
 
+    history : str, default None
+        Specifies the method for selecting the start
+        of the stable history period. Currently only
+        reverse-ordered CUSUM ('ROC') is supported.
+        If history=None (default), the first
+        observation is chosen.
+
     hfrac : float, default 0.25
         Float in the interval (0,1) specifying the
         bandwidth relative to the sample size in
@@ -91,6 +98,7 @@ class BFASTMonitor(object):
             start_monitor,
             freq=365,
             k=3,
+            history=None,
             hfrac=0.25,
             trend=True,
             level=0.05,
@@ -106,6 +114,7 @@ class BFASTMonitor(object):
         self.start_monitor = start_monitor
         self.freq = freq
         self.k = k
+        self.history = history
         self.hfrac = hfrac
         self.trend = trend
         self.level = level
@@ -147,6 +156,7 @@ class BFASTMonitor(object):
                  start_monitor=self.start_monitor,
                  freq=self.freq,
                  k=self.k,
+                 history=self.history,
                  hfrac=self.hfrac,
                  trend=self.trend,
                  level=self.level,
@@ -159,6 +169,7 @@ class BFASTMonitor(object):
                  start_monitor=self.start_monitor,
                  freq=self.freq,
                  k=self.k,
+                 history=self.history,
                  hfrac=self.hfrac,
                  trend=self.trend,
                  level=self.level,
@@ -172,6 +183,7 @@ class BFASTMonitor(object):
                  start_monitor=self.start_monitor,
                  freq=self.freq,
                  k=self.k,
+                 history=self.history,
                  hfrac=self.hfrac,
                  trend=self.trend,
                  level=self.level,
@@ -213,6 +225,7 @@ class BFASTMonitor(object):
             "start_monitor": self.start_monitor,
             "freq": self.freq,
             "k": self.k,
+            "history": self.history,
             "hfrac": self.hfrac,
             "trend": self.trend,
             "level": self.level,
@@ -328,5 +341,21 @@ class BFASTMonitor(object):
         """
         if self._is_fitted():
             return self._model.valids
+
+        raise Exception("Model not yet fitted!")
+
+    @property
+    def history_starts(self):
+        """ Returns index of the start of the stable
+        history period for each pixel
+
+        Returns
+        -------
+         array-like : An array containing indices
+             of starts of the stable history periods
+             in the aray data
+        """
+        if self._is_fitted():
+            return self._model.history_starts
 
         raise Exception("Model not yet fitted!")

--- a/bfast/monitor/opencl/base.py
+++ b/bfast/monitor/opencl/base.py
@@ -72,6 +72,7 @@ class BFASTMonitorOpenCL(BFASTMonitorBase):
                  start_monitor,
                  freq=365,
                  k=3,
+                 history=None,
                  hfrac=0.25,
                  trend=True,
                  level=0.05,

--- a/bfast/monitor/opencl/futhark/futhark.pkg
+++ b/bfast/monitor/opencl/futhark/futhark.pkg
@@ -1,0 +1,3 @@
+require {
+  github.com/diku-dk/sorts 0.4.2 #3b2cfcc0d0256df7cd1f2548f68d85f2453007a0
+}

--- a/bfast/monitor/python/base.py
+++ b/bfast/monitor/python/base.py
@@ -162,6 +162,7 @@ class BFASTMonitorPython(BFASTMonitorBase):
             self.means = rval[:,:,1].astype(np.float32)
             self.magnitudes = rval[:,:,2].astype(np.float32)
             self.valids = rval[:,:,3].astype(np.int32)
+            self.history_starts = rval[:,:,4].astype(np.int32)
         else:
             means_global = np.zeros((data.shape[1], data.shape[2]), dtype=np.float32)
             magnitudes_global = np.zeros((data.shape[1], data.shape[2]), dtype=np.float32)

--- a/bfast/monitor/python/base.py
+++ b/bfast/monitor/python/base.py
@@ -231,8 +231,8 @@ class BFASTMonitorPython(BFASTMonitorBase):
                 print("WARNING: Not enough observations: ns={ns}, Ns={Ns}".format(ns=ns, Ns=Ns))
             return brk, mean, magnitude, Ns, hist_start
 
-        val_inds = val_inds[ns:]
-        val_inds -= self.n
+        val_inds_monitor = val_inds[ns:]
+        val_inds_monitor -= self.n
 
         # remove nan values from patterns+targets
         X_nn = self.X[:, ~nans]
@@ -281,7 +281,7 @@ class BFASTMonitorPython(BFASTMonitorBase):
         mosum_nn = 1.0 / (sigma * np.sqrt(ns)) * mosum_nn
 
         mosum = np.repeat(np.nan, N - self.n)
-        mosum[val_inds[:Ns - ns]] = mosum_nn
+        mosum[val_inds_monitor[:Ns - ns]] = mosum_nn
         if self.verbose:
             print("MOSUM process", mosum_nn.shape)
 

--- a/bfast/monitor/utils.py
+++ b/bfast/monitor/utils.py
@@ -548,16 +548,19 @@ def _pval_brownian_motion_max(x):
 def rcusum(X, y):
     k, n = X.shape
     w = recresid(X.T, y)
-    sigma = np.std(w)
+    sigma = np.std(w, ddof=1) # ddof=1 for sample sd
     process = np.nancumsum(np.append([0],w))/(sigma*np.sqrt(n-k))
     return process
 
+# Used in boundary, but hoisted outside because it is the same for all pixels.
+def compute_confidence_brownian(alpha):
+  return optimize.brentq(lambda x: _pval_brownian_motion_max(x) - alpha, 0, 20)
+
 # Linear boundary for Brownian motion (limiting process of rec.resid. CUSUM).
-def boundary(process, alpha=0.05):
+def boundary(process, confidence):
     n = process.shape[0]
-    lam = optimize.brentq(lambda x: _pval_brownian_motion_max(x) - alpha, 0, 20)
     t = np.linspace(0, 1, num=n)
-    bounds = lam + (2*lam*t) # from Zeileis' strucchange description.
+    bounds = confidence + (2*confidence*t) # from Zeileis' strucchange description.
     return bounds
 
 # Structural change test for Brownian motion.

--- a/bfast/monitor/utils.py
+++ b/bfast/monitor/utils.py
@@ -499,7 +499,7 @@ def recresid(X, y, tol=None):
     assert(n == y.shape[0])
 
     if tol is None:
-        tol = np.finfo(np.float32).eps / k
+        tol = np.sqrt(np.finfo(np.float32).eps) / k
 
     y = y.reshape(n, 1)
     ret = np.zeros(n - k)

--- a/bfast/monitor/utils.py
+++ b/bfast/monitor/utils.py
@@ -548,8 +548,8 @@ def _pval_brownian_motion_max(x):
 def rcusum(X, y):
     k, n = X.shape
     w = recresid(X.T, y)
-    sigma = np.std(w, ddof=1) # ddof=1 for sample sd
-    process = np.nancumsum(np.append([0],w))/(sigma*np.sqrt(n-k))
+    s = np.std(w, ddof=1) # ddof=1 for sample sd
+    process = np.nancumsum(np.append([0],w))/(s*np.sqrt(n-k))
     return process
 
 # Used in boundary, but hoisted outside because it is the same for all pixels.

--- a/bfast/monitor/utils.py
+++ b/bfast/monitor/utils.py
@@ -499,7 +499,7 @@ def recresid(X, y, tol=None):
     assert(n == y.shape[0])
 
     if tol is None:
-        tol = np.sqrt(np.finfo(np.float32).eps) / k
+        tol = np.sqrt(np.finfo(np.float64).eps) / k
 
     y = y.reshape(n, 1)
     ret = np.zeros(n - k)

--- a/examples/roc_python.py
+++ b/examples/roc_python.py
@@ -1,0 +1,113 @@
+import os
+import wget
+import time
+import copy
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib
+from datetime import datetime
+from functools import wraps
+
+from bfast import BFASTMonitor
+from bfast.monitor.utils import crop_data_dates
+
+# parameters
+k = 3
+freq = 365
+trend = False
+hfrac = 0.25
+level = 0.05
+start_hist = datetime(2002, 1, 1)
+start_monitor = datetime(2010, 1, 1)
+end_monitor = datetime(2018, 1, 1)
+
+# download and parse input data
+ifile_meta = "data/peru_small/dates.txt"
+ifile_data = "data/peru_small/data.npy"
+
+if not os.path.isdir("data/peru_small"):
+    os.makedirs("data/peru_small")
+
+if not os.path.exists(ifile_meta):
+    url = 'https://sid.erda.dk/share_redirect/fcwjD77gUY/dates.txt'
+    wget.download(url, ifile_meta)
+if not os.path.exists(ifile_data):
+    url = 'https://sid.erda.dk/share_redirect/fcwjD77gUY/data.npy'
+    wget.download(url, ifile_data)
+
+data_orig = np.load(ifile_data)
+with open(ifile_meta) as f:
+    dates = f.read().split('\n')
+    dates = [datetime.strptime(d, '%Y-%m-%d') for d in dates if len(d) > 0]
+
+data, dates = crop_data_dates(data_orig, dates, start_hist, end_monitor)
+print("First date: {}".format(dates[0]))
+print("Last date: {}".format(dates[-1]))
+print("Shape of data array: {}".format(data.shape))
+
+model = BFASTMonitor(
+            start_monitor,
+            freq=freq,
+            k=k,
+            history="ROC",
+            hfrac=hfrac,
+            trend=trend,
+            level=level,
+            backend='python',
+            verbose=0,
+            device_id=0,
+        )
+
+
+FILENAME = "peru_hist.npy"
+
+if os.path.exists(FILENAME):
+  with open(FILENAME, "rb") as f:
+    hist = np.load(f)
+else:
+  start_time = time.time()
+  model.fit(data, dates, n_chunks=5, nan_value=-32768)
+  end_time = time.time()
+  print("All computations have taken {} seconds.".format(end_time - start_time))
+  hist = model.history_starts
+  with open(FILENAME, "wb") as f:
+    np.save(f, hist)
+
+  
+# visualize results
+not_enough_obs = hist == -2
+hist = hist.astype(np.float)
+hist[not_enough_obs] = np.nan
+
+dates = np.array(dates)
+idx_start_2003 = np.argmax((dates >= datetime(2003, 1, 1)) > False)
+idx_start_2004 = np.argmax((dates >= datetime(2004, 1, 1)) > False)
+idx_start_2005 = np.argmax((dates >= datetime(2005, 1, 1)) > False)
+idx_start_2006 = np.argmax((dates >= datetime(2006, 1, 1)) > False)
+idx_start_2007 = np.argmax((dates >= datetime(2007, 1, 1)) > False)
+idx_start_2008 = np.argmax((dates >= datetime(2008, 1, 1)) > False)
+idx_start_2009 = np.argmax((dates >= datetime(2009, 1, 1)) > False)
+idx_start_2010 = np.argmax((dates >= datetime(2010, 1, 1)) > False)
+
+hist_years = copy.deepcopy(hist)
+hist_years[hist <= idx_start_2003] = 0
+hist_years[np.where(np.logical_and(idx_start_2003 < hist, hist <= idx_start_2004))] = 1
+hist_years[np.where(np.logical_and(idx_start_2004 < hist, hist <= idx_start_2005))] = 2
+hist_years[np.where(np.logical_and(idx_start_2005 < hist, hist <= idx_start_2006))] = 3
+hist_years[np.where(np.logical_and(idx_start_2006 < hist, hist <= idx_start_2007))] = 4
+hist_years[np.where(np.logical_and(idx_start_2007 < hist, hist <= idx_start_2008))] = 5
+hist_years[np.where(np.logical_and(idx_start_2008 < hist, hist <= idx_start_2009))] = 6
+hist_years[np.where(np.logical_and(idx_start_2009 < hist, hist <= idx_start_2010))] = 7
+hist_years[np.where(idx_start_2010 < hist)] = 8
+
+bounds = np.linspace(0, 8, 9)
+cmap = matplotlib.cm.get_cmap("gist_yarg", 9)
+
+fig, axes = plt.subplots(nrows=1, ncols=1, figsize=(10, 10))
+im = axes.imshow(hist_years, cmap=cmap, vmin=0, vmax=8)
+fig.subplots_adjust(right=0.8)
+cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
+fig.colorbar(im, cax=cbar_ax, ticks=[0, 1, 2, 3, 4, 5, 6, 7, 8])
+labels = cbar_ax.set_yticklabels(['nan', '2003', '2004', '2005', '2006', '2007', '2008', '2009', '2010'])
+
+plt.savefig("peru_python_roc1.png")

--- a/examples/stable_history.py
+++ b/examples/stable_history.py
@@ -96,14 +96,14 @@ idx_start_2009 = np.argmax((dates >= datetime(2009, 1, 1)) > False)
 idx_start_2010 = np.argmax((dates >= datetime(2010, 1, 1)) > False)
 
 hist_years = copy.deepcopy(hist)
-hist_years[hist <= idx_start_2003] = 0
-hist_years[np.where(np.logical_and(idx_start_2003 < hist, hist <= idx_start_2004))] = 1
-hist_years[np.where(np.logical_and(idx_start_2004 < hist, hist <= idx_start_2005))] = 2
-hist_years[np.where(np.logical_and(idx_start_2005 < hist, hist <= idx_start_2006))] = 3
-hist_years[np.where(np.logical_and(idx_start_2006 < hist, hist <= idx_start_2007))] = 4
-hist_years[np.where(np.logical_and(idx_start_2007 < hist, hist <= idx_start_2008))] = 5
-hist_years[np.where(np.logical_and(idx_start_2008 < hist, hist <= idx_start_2009))] = 6
-hist_years[np.where(np.logical_and(idx_start_2009 < hist, hist <= idx_start_2010))] = 7
+hist_years[np.isnan(hist)] = 0
+hist_years[np.where(np.logical_and(idx_start_2003 <= hist, hist < idx_start_2004))] = 1
+hist_years[np.where(np.logical_and(idx_start_2004 <= hist, hist < idx_start_2005))] = 2
+hist_years[np.where(np.logical_and(idx_start_2005 <= hist, hist < idx_start_2006))] = 3
+hist_years[np.where(np.logical_and(idx_start_2006 <= hist, hist < idx_start_2007))] = 4
+hist_years[np.where(np.logical_and(idx_start_2007 <= hist, hist < idx_start_2008))] = 5
+hist_years[np.where(np.logical_and(idx_start_2008 <= hist, hist < idx_start_2009))] = 6
+hist_years[np.where(np.logical_and(idx_start_2009 <= hist, hist < idx_start_2010))] = 7
 hist_years[np.where(idx_start_2010 < hist)] = 8
 
 bounds = np.linspace(0, 8, 9)

--- a/examples/stable_history.py
+++ b/examples/stable_history.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 import wget
 import time
 import copy
@@ -10,6 +11,11 @@ from functools import wraps
 
 from bfast import BFASTMonitor
 from bfast.monitor.utils import crop_data_dates
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--backend", type=str, action="store", default="python",
+                    help="backend for BFASTMonitor")
+args = parser.parse_args()
 
 # parameters
 k = 3
@@ -29,16 +35,16 @@ if not os.path.isdir("data/peru_small"):
     os.makedirs("data/peru_small")
 
 if not os.path.exists(ifile_meta):
-    url = 'https://sid.erda.dk/share_redirect/fcwjD77gUY/dates.txt'
+    url = "https://sid.erda.dk/share_redirect/fcwjD77gUY/dates.txt"
     wget.download(url, ifile_meta)
 if not os.path.exists(ifile_data):
-    url = 'https://sid.erda.dk/share_redirect/fcwjD77gUY/data.npy'
+    url = "https://sid.erda.dk/share_redirect/fcwjD77gUY/data.npy"
     wget.download(url, ifile_data)
 
 data_orig = np.load(ifile_data)
 with open(ifile_meta) as f:
-    dates = f.read().split('\n')
-    dates = [datetime.strptime(d, '%Y-%m-%d') for d in dates if len(d) > 0]
+    dates = f.read().split("\n")
+    dates = [datetime.strptime(d, "%Y-%m-%d") for d in dates if len(d) > 0]
 
 data, dates = crop_data_dates(data_orig, dates, start_hist, end_monitor)
 print("First date: {}".format(dates[0]))
@@ -53,7 +59,7 @@ model = BFASTMonitor(
             hfrac=hfrac,
             trend=trend,
             level=level,
-            backend='python',
+            backend=args.backend,
             verbose=0,
             device_id=0,
         )
@@ -74,7 +80,7 @@ else:
     np.save(f, hist)
 
   
-# visualize results
+# visualize stable history starts
 not_enough_obs = hist == -2
 hist = hist.astype(np.float)
 hist[not_enough_obs] = np.nan
@@ -108,6 +114,6 @@ im = axes.imshow(hist_years, cmap=cmap, vmin=0, vmax=8)
 fig.subplots_adjust(right=0.8)
 cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])
 fig.colorbar(im, cax=cbar_ax, ticks=[0, 1, 2, 3, 4, 5, 6, 7, 8])
-labels = cbar_ax.set_yticklabels(['nan', '2003', '2004', '2005', '2006', '2007', '2008', '2009', '2010'])
+labels = cbar_ax.set_yticklabels(["nan", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010"])
 
-plt.savefig("peru_python_roc1.png")
+plt.savefig("peru_roc.png")


### PR DESCRIPTION
Only for python/python-mp backends. I imagine we can talk about validation against R at the next meeting (it validates ~~with very few outliers~~). Here is a visualisation of the start of the stable history period for each pixel in peru small:
![peru_roc_scaled](https://user-images.githubusercontent.com/10325981/111031624-bcf96d80-8408-11eb-9cc8-e250cb0a7b27.png)
It was generated with `python examples/stable_history.py --backend=python-mp`.

`validator.py` still validates (ie. when not using ROC).