### PR TITLE
Add trend number to parameter calculation

### DIFF
--- a/bfast/monitor/python/base.py
+++ b/bfast/monitor/python/base.py
@@ -255,7 +255,7 @@ class BFASTMonitorPython(BFASTMonitorBase):
         err_cs = np.cumsum(y_error[ns - h:Ns + 1])
         mosum_nn = err_cs[h:] - err_cs[:-h]
 
-        sigma = np.sqrt(np.sum(y_error[:ns] ** 2) / (ns - (2 + 2 * self.k)))
+        sigma = np.sqrt(np.sum(y_error[:ns] ** 2) / (ns - (1 + int(self.trend) + 2 * self.k)))
         mosum_nn = 1.0 / (sigma * np.sqrt(ns)) * mosum_nn
 
         mosum = np.repeat(np.nan, N - self.n)


### PR DESCRIPTION
Hi, 

Unless I'm mistaken sigma is the residual standard deviation, so the denominator should be the d.o.f. i.e. `sample_size - number_params` which in this case will be `2 * k + 1` if there is no trend or `2 * k + 2` if there is a trend. 

It seems it was hardcoded to the case where there is a trend, so this should fix it. 

I am unsure about the [futhark implementation](https://github.com/diku-dk/bfast/blob/4fd0c1727ec6ac309966d0ecfeef67e3ef02776b/bfast/monitor/opencl/futhark/bfastfinal.fut#L27): it seems to into account the fact that there are fewer parameters when not calculating a trend, but frankly it's greek to me so I am unsure if it's actually being used. 